### PR TITLE
Beside ASPNETCORE_URLS use also —urls

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -134,6 +134,6 @@ if [ -e ${SRC_DIR}/Procfile ]; then
 	cp ${SRC_DIR}/Procfile ${BUILD_DIR}
 else
 	cat << EOT >> ${BUILD_DIR}/Procfile
-web: ASPNETCORE_URLS='http://+:\$PORT' dotnet ./app.dll
+web: ASPNETCORE_URLS='http://+:\$PORT' dotnet ./app.dll --urls http://+:\$PORT
 EOT
 fi


### PR DESCRIPTION
The [Procfile provided by default](https://github.com/friism/dotnet-buildpack/blob/master/bin/compile#L137) is: `web: ASPNETCORE_URLS='http://+:$PORT' dotnet ./app.dll`

[Documentation says](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/hosting):
> to set the URLs the server will listen on **by default**, you would set `ASPNETCORE_URLS`

The *by default* is important here.

Examples:

- ~~`UseUrls()`~~  ~~`.AddCommandLine(args)`~~
```C#
        public static void Main(string[] args)
        {
            var host = new WebHostBuilder()
                .UseKestrel()
                .UseContentRoot(Directory.GetCurrentDirectory())
                .UseIISIntegration()
                .UseStartup<Startup>()
                .Build();

            host.Run();
        }
```
```Shell
$ dotnet run
Now listening on: http://localhost:5000

$ ASPNETCORE_URLS='http://localhost:8000' dotnet run 
Now listening on: http://localhost:8000

$ dotnet run --urls='http://localhost:8000'
Now listening on: http://localhost:5000

$ ASPNETCORE_URLS='http://localhost:8000' dotnet run --urls='http://localhost:8000'
Now listening on: http://localhost:8000
```

- `UseUrls()`  ~~`.AddCommandLine(args)`~~
```C#
        public static void Main(string[] args)
        {
            var host = new WebHostBuilder()
                .UseUrls("http://localhost:8000")
                .UseKestrel()
                .UseContentRoot(Directory.GetCurrentDirectory())
                .UseIISIntegration()
                .UseStartup<Startup>()
                .Build();

            host.Run();
        }
```
```Shell
$ dotnet run 
Now listening on: http://localhost:8000

$ ASPNETCORE_URLS='http://localhost:9000' dotnet run 
Now listening on: http://localhost:8000

$ dotnet run --urls='http://localhost:9000'
Now listening on: http://localhost:8000

$ ASPNETCORE_URLS='http://localhost:9000' dotnet run --urls='http://localhost:9000'
Now listening on: http://localhost:8000
```

- `UseUrls()`  `.AddCommandLine(args)`
```C#
        public static void Main(string[] args)
        {
            var config = new ConfigurationBuilder()
                .AddCommandLine(args)
                .Build();

            var host = new WebHostBuilder()
                .UseUrls("http://localhost:8000")
                .UseConfiguration(config)
                .UseKestrel()
                .UseContentRoot(Directory.GetCurrentDirectory())
                .UseIISIntegration()
                .UseStartup<Startup>()
                .Build();

            host.Run();
        }
```
```Shell
$ dotnet run 
Now listening on: http://localhost:8000

$ ASPNETCORE_URLS='http://localhost:9000' dotnet run 
Now listening on: http://localhost:8000

$ dotnet run --urls='http://localhost:9000'
Now listening on: http://localhost:9000

$ ASPNETCORE_URLS='http://localhost:9000' dotnet run --urls='http://localhost:9000'
Now listening on: http://localhost:9000
```

- ~~`UseUrls()`~~  `.AddCommandLine(args)`
```C#
        public static void Main(string[] args)
        {
            var config = new ConfigurationBuilder()
                .AddCommandLine(args)
                .Build();

            var host = new WebHostBuilder()
                .UseConfiguration(config)
                .UseKestrel()
                .UseContentRoot(Directory.GetCurrentDirectory())
                .UseIISIntegration()
                .UseStartup<Startup>()
                .Build();

            host.Run();
        }
```
```Shell
$ dotnet run 
Now listening on: http://localhost:5000

$ ASPNETCORE_URLS='http://localhost:9000' dotnet run 
Now listening on: http://localhost:9000

$ dotnet run --urls='http://localhost:9000'
Now listening on: http://localhost:9000

$ ASPNETCORE_URLS='http://localhost:9000' dotnet run --urls='http://localhost:9000'
Now listening on: http://localhost:9000
```

**Conclusion:**
The buildpack should generate this `Procfile`:
`web: ASPNETCORE_URLS='http://+:$PORT' dotnet ./app.dll --urls http://+:$PORT`

('http://+:$PORT' => 'http://+:**\\**$PORT' inside buildpack source code)
